### PR TITLE
Wrong options' names in "prevent new users from creating new tags"

### DIFF
--- a/qa-tt-layer.php
+++ b/qa-tt-layer.php
@@ -27,7 +27,7 @@ class qa_html_theme_layer extends qa_html_theme_base
 				"	{\n" .
 				"		if ( tags[i].length > 0 && alltags.indexOf(','+tags[i]+',') == -1 )\n" .
 				"		{\n" .
-				"			var error = '<div style=\"display:none\" class=\"qa-form-tall-error qa-tag-synonyms-error\">The tag \"'+tags[i]+'\" does not exist; you need " . number_format( qa_opt('tag_synonyms_rep') ) . " points to create new tags.</div>';\n" .
+				"			var error = '<div style=\"display:none\" class=\"qa-form-tall-error qa-tag-synonyms-error\">The tag \"'+tags[i]+'\" does not exist; you need " . number_format( qa_opt('tagging_tools_rep') ) . " points to create new tags.</div>';\n" .
 				"			jQuery(error).insertAfter('#tags').slideDown('fast').delay(5000).slideUp('fast', function() { jQuery(this).detach() } );\n" .
 				"			return false;\n" .
 				"		}\n" .
@@ -50,12 +50,12 @@ class qa_html_theme_layer extends qa_html_theme_base
 	function _forbid_new_tag()
 	{
 		$q_edit = $this->template == 'ask' || isset( $this->content['form_q_edit'] );
-		$tag_prevent = qa_opt('tag_synonyms_prevent');
+		$tag_prevent = qa_opt('tagging_tools_prevent');
 
 		if ( $q_edit && $tag_prevent )
 		{
 			return
-				qa_get_logged_in_points() < (int) qa_opt('tag_synonyms_rep') &&
+				qa_get_logged_in_points() < (int) qa_opt('tagging_tools_rep') &&
 				qa_get_logged_in_level() < QA_USER_LEVEL_EXPERT;
 		}
 


### PR DESCRIPTION
I've updated options' names from 'tag_synonyms_' to 'taggings_tools'.
