### PR TITLE
.load() changed after jquery 1.8

### DIFF
--- a/tag-admin.js
+++ b/tag-admin.js
@@ -26,4 +26,4 @@ function ajax_retag()
 	});
 }
 
-$(window).load(ajax_retag);
+$(window).on('load', ajax_retag);


### PR DESCRIPTION
https://github.com/svivian/q2a-tagging-tools/issues/22